### PR TITLE
replacing tally() with summarise() to avoide a warning dplyr 1.0.1 emits

### DIFF
--- a/R/DEL-model.R
+++ b/R/DEL-model.R
@@ -99,8 +99,7 @@ DEL.SC <- function(x, ..., max_area = NULL)  {
   edge_per_object_lt <- x$object["object_"] %>%
     dplyr::inner_join(x$object_link_edge, "object_") %>%
     dplyr::inner_join(x$object_link_edge, "object_") %>%
-
-    dplyr::group_by(.data$object_) %>% dplyr::tally(dplyr::n()) %>% dplyr::filter(.data$n < 3)
+    dplyr::group_by(.data$object_) %>% dplyr::summarise(n = dplyr::n()) %>% dplyr::filter(.data$n < 3)
   if (nrow(edge_per_object_lt) > 0) {
     message("dropping untriangulatable objects")
     ## need anti_join.sc


### PR DESCRIPTION
Because of a change in `dplyr` 1.0.0 one of the tests fails because it is expected to be silent and now issues a warning: 

```r
test_that("SC0 round trip suite works", {
  expect_silent({
    ## these test had to be removed from silicate, because dep on anglr
    anglr::DEL(SC(sc0))
    plot(anglr::DEL(SC(sc0)))

    anglr::DEL(sc)
    plot(anglr::DEL(sc))
    
    
    anglr::DEL(SC(sc))
    plot(anglr::DEL(SC(sc)))
    
    
    anglr::DEL(SC(tri))
    plot(anglr::DEL(SC(tri)))
    
    DEL(sc0)
    plot(DEL(sc0))
    
    DEL(tri)
    plot(DEL(tri))
  })
})
```

Changing from `tally()` to `summarise()` does the same thing and silences the warning. 

We are in the process of releasing `dplyr` 1.0.1., but this fix works also with the previous versions. Would you consider releasing `anglr` with this change ?